### PR TITLE
Add the library location on solaris

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -117,7 +117,8 @@ if not libmagic or not libmagic._name:
     import sys
     platform_to_lib = {'darwin': ['/opt/local/lib/libmagic.dylib', 
                                   '/usr/local/lib/libmagic.dylib'],
-                       'win32':  ['magic1.dll']}
+                       'win32':  ['magic1.dll'],
+                       'sunos5': ['/opt/local/lib/libmagic.so']}
     for dll in platform_to_lib.get(sys.platform, []):
         try:
             libmagic = ctypes.CDLL(dll)


### PR DESCRIPTION
On solaris (joyent VM), libmagic isn't found by default by ctypes.  Add it to the list of locations.
