### PR TITLE
Check if 'magic_close' still has a value on __del__()

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -69,7 +69,7 @@ class Magic:
         return magic_file(self.cookie, filename)
 
     def __del__(self):
-        if self.cookie:
+        if self.cookie and magic_close:
             magic_close(self.cookie)
             self.cookie = None
 


### PR DESCRIPTION
Sometimes when my program was exiting I would catch:

```
Exception TypeError: "'NoneType' object is not callable" in <bound method Magic.__del__ of <magic.Magic instance at 0x110381050>> ignored
```
