### PR TITLE
Use os.path.lexists instead of os.path.exists

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -64,7 +64,7 @@ class Magic:
         raises IOError if the file does not exist
         """
 
-        if not os.path.exists(filename):
+        if not os.path.lexists(filename):
             raise IOError("File does not exist: " + filename)
 
         return magic_file(self.cookie, filename)


### PR DESCRIPTION
So we can get a ' broken symbolic link to ...' result for broken symlinks instead of exception.

