### PR TITLE
Fixed 'ImportError: failed to find libmagic.  Check your installation' when using cygwin's python

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -159,11 +159,13 @@ if dll:
     libmagic = ctypes.CDLL(dll)
 
 if not libmagic or not libmagic._name:
+    windows_dlls = ['magic1.dll','cygmagic-1.dll']
     platform_to_lib = {'darwin': ['/opt/local/lib/libmagic.dylib',
                                   '/usr/local/lib/libmagic.dylib'] +
                          # Assumes there will only be one version installed
                          glob.glob('/usr/local/Cellar/libmagic/*/lib/libmagic.dylib'),
-                       'win32':  ['magic1.dll','cygmagic-1.dll']}
+                       'win32': windows_dlls,
+                       'cygwin': windows_dlls }
     for dll in platform_to_lib.get(sys.platform, []):
         try:
             libmagic = ctypes.CDLL(dll)


### PR DESCRIPTION
When using cygwin, and python distribution, that comes with it, `sys.platform` is equal to "cygwin", rather than "win32".
So I made this value be treated the same in magic.py

Test Plan:
    $ /bin/python
    >>> import magic
    >>> # Ensure no error message displayed
    >>> exit()
