### PR TITLE
fix MAGIC_MIME_TYPE value

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -276,9 +276,11 @@ MAGIC_COMPRESS = 0x000004 # Check inside compressed files
 
 MAGIC_DEVICES = 0x000008 # Look at the contents of devices
 
-MAGIC_MIME = 0x000010 # Return a mime string
+MAGIC_MIME_TYPE = 0x000010 # Return a MIME type
 
 MAGIC_MIME_ENCODING = 0x000400 # Return the MIME encoding
+
+MAGIC_MIME = MAGIC_MIME_TYPE | MAGIC_MIME_ENCODING
 
 MAGIC_CONTINUE = 0x000020 # Return all matches
 


### PR DESCRIPTION
In https://github.com/file/file/blob/master/src/magic.h.in#L44 , the macro are defined as follows:

``` C
#define MAGIC_MIME_TYPE     0x000010 /* Return the MIME type */
#define MAGIC_MIME_ENCODING 0x000400 /* Return the MIME encoding */
#define MAGIC_MIME      (MAGIC_MIME_TYPE|MAGIC_MIME_ENCODING)
```

But in https://github.com/ahupp/python-magic/blob/master/magic.py#L279 , variables are defined as follows:

``` python
MAGIC_MIME = 0x000010 # Return a mime string

MAGIC_MIME_ENCODING = 0x000400 # Return the MIME encoding
```

So is this a bug? Fix it:

``` python
MAGIC_MIME_TYPE = 0x000010 # Return a MIME type

MAGIC_MIME_ENCODING = 0x000400 # Return the MIME encoding

MAGIC_MIME = MAGIC_MIME_TYPE | MAGIC_MIME_ENCODING
```
