### PR TITLE
Added context managers, rename method

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -99,7 +99,7 @@ class Magic:
                             'from_file or from_buffer, or carefully manage direct '
                             'use of the Magic class')
 
-    def __del__(self):
+    def close(self):
         # no _thread_check here because there can be no other
         # references to this object at this point.
 
@@ -113,6 +113,14 @@ class Magic:
         if self.cookie and magic_close:
             magic_close(self.cookie)
             self.cookie = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    __del__ = close
 
 
 instances = threading.local()

--- a/test.py
+++ b/test.py
@@ -74,5 +74,12 @@ class MagicTest(unittest.TestCase):
         m = magic.Magic(mime=True, keep_going=True)
         self.assertEqual(m.from_file(filename), 'image/jpeg'.encode('utf-8'))
 
+    def test_context_manager(self):
+        m = magic.Magic(mime=True)
+        with m as ctx:
+            assert ctx is m
+
+        assert not m.cookie
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The reason ``__del__`` was aliased to close instead was because it will enable users to programatically close the ``Magic`` wrapper instead of needing to wait for the GC to kick in. A context manager was added to make that easier as well:

```python
libmagic = Magic()
with libmagic:
    # do something here

assert not libmagic.cookie # it's closed!
```