### PR TITLE
Change windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Other sources:
 
 ### Dependencies
 
-On Windows, copy magic1.dll, regex2.dll, and zlib1.dll onto your PATH from the Binaries and Dependencies zipfiles provided by the [File for Windows](http://gnuwin32.sourceforge.net/packages/file.htm) project.
+On Windows, copy magic1.dll, regex2.dll, and zlib1.dll onto your PATH from the Binaries and Dependencies zipfiles provided by the [File for Windows](http://gnuwin32.sourceforge.net/packages/file.htm) project.  You will need to copy the file `magic` out of `[binary-zip]\share\misc`, and pass it's location to `Magic(magic_file=...)`
 
 On OSX:
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ Other sources:
 
 ### Dependencies
 
-On Windows, install Cygwin (http://cygwin.com/install.html).  To find
-the libraries, either add <your-cygwin-install>/bin to the $PATH or
-copy cygwin1.dll, cygz.dll, and cygmagic-1.dll to C:\Windows\System32
+On Windows, copy magic1.dll, regex2.dll, and zlib1.dll onto your PATH from the Binaries and Dependencies zipfiles provided by the [File for Windows](http://gnuwin32.sourceforge.net/packages/file.htm) project.
 
 On OSX:
 


### PR DESCRIPTION
Cygwin is huge and slow.  File for Windows does not go through a posix translation layer, and are native windows libraries.  It is much less of a pain in the butt to use File for Windows.