### PR TITLE
Match license= to LICENSE, Add Python 2 to Trove

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,13 @@ identification library.  It makes use of the local magic database and
 supports both textual and MIME-type output.
 """,
       keywords="mime magic file",
-      license="PSF",
+      license="MIT",
       test_suite='test',
       classifiers=[
           'Intended Audience :: Developers',
           'License :: OSI Approved :: MIT License',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',
       ],
       )


### PR DESCRIPTION
- Update the distutils license field to match MIT license as specified in:
 * LICENSE file in repository
 * Trove classifier
- Add Python :: 2 to trove classifier to declare explicit (PEP20) 2/3 compatibility