### PR TITLE
Remove pruning of tests from sdist's

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include *.py
-prune test
 


### PR DESCRIPTION
Tests are highly valuable for downstream users, packagers and porters to QA packages on their systems.

This change removes the pruning of the tests directory from sdist creation. They are after all, source distributions :)

If you'd like to exclude them from *installation*, then I believe the following may be used in setup.py

```
find_packages(exclude=["tests"]),
```

