### PR TITLE
Include tests in PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include *.py
-prune test
 


### PR DESCRIPTION
Remove pruning the tests directory which restores it presence to source distributions (sdist) on PyPI.

This allows downstream packagers, porters and users to run the tests against and in their environments

Resolves https://github.com/ahupp/python-magic/issues/97