### PR TITLE
Added LICENSE to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include *.py
-
-
+include LICENSE


### PR DESCRIPTION
I've been putting together a build of python-magic for using [conda](http://conda.pydata.org) for [conda-forge](http://conda-forge.github.io). (See [here](https://github.com/conda-forge/staged-recipes/pull/1392).) For license compliance we like to bundle a copy of the original license file in with the build. Doing so requires that the license file be included with the source distribution. Adding this line to MANIFEST.in makes sure that the actual license file gets included with the source code.