### PR TITLE
Handling 'mime' and 'mime_encoding' independently

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -53,7 +53,7 @@ class Magic:
         self.flags = MAGIC_NONE
         if mime:
             self.flags |= MAGIC_MIME
-        elif mime_encoding:
+        if mime_encoding:
             self.flags |= MAGIC_MIME_ENCODING
         if keep_going:
             self.flags |= MAGIC_CONTINUE


### PR DESCRIPTION
The change lets to instantiate a Magic instance with the desired combination of flags and in particular have a mime type and encoding simultaneously if instantiated as
m = magic.Magic(mime=True, mime_encoding=True)