### PR TITLE
Added a fallback for Alpine to find library file

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -160,7 +160,9 @@ if not libmagic or not libmagic._name:
                          # Assumes there will only be one version installed
                          glob.glob('/usr/local/Cellar/libmagic/*/lib/libmagic.dylib'),
                        'win32': windows_dlls,
-                       'cygwin': windows_dlls }
+                       'cygwin': windows_dlls,
+                       'linux': 'libmagic.so.1',    # fallback for some Linuxes (e.g. Alpine) where library search does not work
+                      }
     for dll in platform_to_lib.get(sys.platform, []):
         try:
             libmagic = ctypes.CDLL(dll)


### PR DESCRIPTION
There are some Linuxes that have libraries search broken. This commit would add a reasonable fallback for these systems.
Otherwise python-magic does not work there having "magic" library installed and python-magic from Pypi.