### PR TITLE
Add python 3.6 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "nightly"
 
 install:


### PR DESCRIPTION
Python 3.6 is not considered a nightly anymore so it would be good to explicitly list this as one of the tested python versions.

@ahupp 