### PR TITLE
Accommodate linux distros that return trailing version, i.e. Alpine

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -163,7 +163,8 @@ if not libmagic or not libmagic._name:
                        'cygwin': windows_dlls,
                        'linux': ['libmagic.so.1'],    # fallback for some Linuxes (e.g. Alpine) where library search does not work
                       }
-    for dll in platform_to_lib.get(sys.platform, []):
+    platform = 'linux' if sys.platform.startswith('linux') else sys.platform
+    for dll in platform_to_lib.get(platform, []):
         try:
             libmagic = ctypes.CDLL(dll)
             break


### PR DESCRIPTION
- [x] Resolve #129 

The suggested method for ensuring `sys.platform` check doesn't fail against `linux` platforms despite version is to check .startswith.  See:  http://stackoverflow.com/questions/10415942/python-sys-platform-linux2-but-not-linux3

This resolves `libmagic` detection on Alpine.