### PR TITLE
MagicException extends OSError

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -27,7 +27,7 @@ import threading
 from ctypes import c_char_p, c_int, c_size_t, c_void_p
 
 
-class MagicException(Exception):
+class MagicException(OSError):
     def __init__(self, message):
         super(MagicException, self).__init__(message)
         self.message = message


### PR DESCRIPTION
`MagicException` should extend exception `OSError` instead generic `Exception`.