### PR TITLE
Handle incorrectly encoded file names

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -213,7 +213,7 @@ def coerce_filename(filename):
                   (sys.version_info[0] >= 3 and
                    isinstance(filename, str))
     if is_unicode:
-        return filename.encode('utf-8')
+        return filename.encode('utf-8', 'surrogateescape')
     else:
         return filename
 


### PR DESCRIPTION
i.e. not matching the file system encoding.  For example,
```bash
$ ls ./Metro\ Pakt\ -\ Neue\ Stra�en\ \(1981\).mp3 
'./Metro Pakt - Neue Stra'$'\341''en (1981).mp3'
```
When this file is fed to magic.py...
```
  File "/home/travis/devel/eyeD3/git/src/eyed3/utils/__init__.py", line 46, in guess_type
    return self.from_file(filename)
  File "/home/travis/.virtualenvs/eyeD3/lib/python3.6/site-packages/python_magic-0.4.13-py3.6.egg/magic.py", line 85, in from_file
    return maybe_decode(magic_file(self.cookie, filename))
  File "/home/travis/.virtualenvs/eyeD3/lib/python3.6/site-packages/python_magic-0.4.13-py3.6.egg/magic.py", line 243, in magic_file
    return _magic_file(cookie, coerce_filename(filename))
  File "/home/travis/.virtualenvs/eyeD3/lib/python3.6/site-packages/python_magic-0.4.13-py3.6.egg/magic.py", line 217, in coerce_filename
    return filename.encode('utf-8')
UnicodeEncodeError: 'utf-8' codec can't encode character '\udce1' in position 126: surrogates not allowed
```
This PR fixes this by allowing "surrogrates" which thru black magic mysteriously means that the file can then be dealt with i.e. magic.py correctly processes and returns audio/mp3.
```bash
$ eyeD3 ./Metro\ Pakt\ -\ Neue\ Stra�en\ \(1981\).mp3 
...efcase _-_Part-2_(VBR_V-6)/Metro Pakt - Neue Stra?en (1981).mp3 [ 2.66 MB ]
-------------------------------------------------------------------------------
Time: 02:40	MPEG1, Layer III	[ ~139 kb/s @ 44100 Hz - Joint stereo ]
-------------------------------------------------------------------------------
```