### PR TITLE
Only install coveralls and codecov when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,11 @@ python:
   - "nightly"
 
 install:
-  - pip install coveralls
-  - pip install codecov
   - python setup.py install
 
 script:
   - coverage run setup.py test
 
 after_success:
-  - coveralls
-  - codecov
+  - pip install coveralls && coveralls
+  - pip install codecov && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ python:
   - "nightly"
 
 install:
+  - pip install coverage
   - python setup.py install
 
 script:


### PR DESCRIPTION
No need to download/install for failing builds