### PR TITLE
Fix the CI

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -87,7 +87,7 @@ class MagicTest(unittest.TestCase):
         self.assertEqual(m.from_file(filename), 'image/jpeg')
         
         m = magic.Magic(mime=True, keep_going=True)
-        self.assertEqual(m.from_file(filename), 'image/jpeg\\012- application/octet-stream')
+        self.assertEqual(m.from_file(filename), 'image/jpeg')
 
 
     def test_rethrow(self):


### PR DESCRIPTION
Revert "update filetype reported by libmagic >=5.23 for keep_going=true"

This reverts commit 9d127ceaab1da0632128422ffd6a2d340bd3e778 and fixes https://github.com/ahupp/python-magic/issues/148.