### PR TITLE
Allow x-gzip as MIME type for gzip files, fixes #96

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -54,7 +54,7 @@ class MagicTest(unittest.TestCase):
             self.assert_values(m, {
                 'magic._pyc_': 'application/octet-stream',
                 'test.pdf': 'application/pdf',
-                'test.gz': 'application/gzip',
+                'test.gz': ('application/gzip', 'application/x-gzip'),
                 'text.txt': 'text/plain',
                 b'\xce\xbb'.decode('utf-8'): 'text/plain',
                 b'\xce\xbb': 'text/plain',


### PR DESCRIPTION
Hi,
It seems that, when #96 was opened, there was no behaviour to select two acceptable output values for a test. Now that the mechanism exists, it's easy to make this test pass.