### PR TITLE
Include the whole test subdirectory in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include *.py
 include LICENSE
+graft tests
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
We at Gentoo currently have to rely on the GitHub tarball to run tests because one of the test data files is missing:
```
======================================================================
ERROR: test_descriptions (__main__.MagicTest)                           
----------------------------------------------------------------------                                                                                                                                            
Traceback (most recent call last):                                                                                                                                                                                
  File "test/test.py", line 73, in test_descriptions                                                                                                                                                              
    }, buf_equals_file=False)                                                                                                                                                                                     
  File "test/test.py", line 24, in assert_values                                                                                                                                                                  
    with open(filename, 'rb') as f:                                                                                                                                                                               
IOError: [Errno 2] No such file or directory: 'test/testdata/magic._pyc_'                                                                                                                                         
```
I'm not really sure why this file was excluded when you created the tarball but this change should ensure that the whole test directory is included. Please let me know if that works. On my system, the tarball created with `setup.py sdist` did contain the missing file.
```
$ tar tvf dist/python-magic-0.4.15.tar.gz | grep python-magic-0.4.15/test/testdata/magic._pyc_
-rw-r--r-- sbraz/sbraz    1797 2018-08-13 11:15 python-magic-0.4.15/test/testdata/magic._pyc_

```