### PR TITLE
minor update to readme.md file as 1048 bytes are not enough for all m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ functionality is exposed to the command line by the Unix command
 >>> import magic
 >>> magic.from_file("testdata/test.pdf")
 'PDF document, version 1.2'
->>> magic.from_buffer(open("testdata/test.pdf").read(1024))
+>>> magic.from_buffer(open("testdata/test.pdf").read(2048)) # use at least 2048 bytes here for safe detection of for example "xslx" files
 'PDF document, version 1.2'
 >>> magic.from_file("testdata/test.pdf", mime=True)
 'application/pdf'


### PR DESCRIPTION
…ime-types

I had an issue with some "xslx" files being detected as "application/zip" instead of the proper spreadsheet mime type. While debugging I found that as it's in general a zip-based format the magic checker has to dive deeper and find a relevant file in the zip to be sure. 

see here: https://github.com/threatstack/libmagic/blob/master/magic/Magdir/msooxml

using only 1024 bytes in the buffer was not enough for this detection in some cases.

I mean a better fix would of course be to hand the whole file-stream over to the magick detector so that it could seek to wherever needed. However at least as a quick-fix I would recommend to have 2048 bytes as the example on how to create the buffer so that detection accuracy for at least this problem will be solved.