### PR TITLE
Fix bug in Magic when destructor called too early

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -48,6 +48,8 @@ class Magic:
         uncompress - Try to look inside compressed files.
         raw - Do not try to decode "non-printable" chars.
         """
+
+        self.cookie = None
         self.flags = MAGIC_NONE
         if mime:
             self.flags |= MAGIC_MIME_TYPE


### PR DESCRIPTION
Potentially `magic_open` may fail, and when python attempts to gc the Magic instance it fails with:
```
Exception ignored in: <function Magic.__del__ at 0x7f595ba06430>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/magic.py", line 129, in __del__
    if self.cookie and magic_close:
AttributeError: 'Magic' object has no attribute 'cookie'
```