### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 install:
   - pip install coverage

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='python-magic',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: Implementation :: CPython',
       ],
       )

--- a/test/run.py
+++ b/test/run.py
@@ -29,4 +29,4 @@ def run_test(versions):
         sys.exit("No versions found: " + str(versions))
 
 run_test(["python2", "python2.7"])
-run_test(["python3.5", "python3.6", "python3.7", "python3.8"])
+run_test(["python3.5", "python3.6", "python3.7", "python3.8", "python3.9"])

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py36,
     py37,
     py38,
+    py39,
     coverage-report,
     mypy
 


### PR DESCRIPTION
Add Python 3.9 to PyPI classifiers and test configs.