### PR TITLE
Support file 5.41.

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -90,7 +90,7 @@ class MagicTest(unittest.TestCase):
         try:
             m = magic.Magic(mime=True)
             self.assert_values(m, {
-                'magic._pyc_': ('application/octet-stream', 'text/x-bytecode.python'),
+                'magic._pyc_': ('application/octet-stream', 'text/x-bytecode.python', 'application/x-bytecode.python'),
                 'test.pdf': 'application/pdf',
                 'test.gz': ('application/gzip', 'application/x-gzip'),
                 'test.snappy.parquet': 'application/octet-stream',


### PR DESCRIPTION
In https://github.com/file/file/commit/7d9b0f0d853957ad88dae0f440fecd58d2740ca7,
the MIME was changed for Python bytecode.
