### PR TITLE
Include type stubs in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     packages=['magic'],
     package_data={
-        'magic': ['py.typed'],
+        'magic': ['py.typed', '__init__.pyi'],
     },
     keywords="mime magic file",
     license="MIT",


### PR DESCRIPTION
Type annotations are provided in the source file `magic/__init__.pyi`, but are not bundled in the package:

```console
$ python setup.py sdist
$ tar -tvf dist/python-magic-0.4.24.tar.gz | grep /magic/
drwx------ vivien/vivien     0 2021-12-30 10:47 python-magic-0.4.24/magic/
-rw------- vivien/vivien 14964 2021-12-30 10:43 python-magic-0.4.24/magic/__init__.py
-rw------- vivien/vivien  8316 2021-12-30 10:43 python-magic-0.4.24/magic/compat.py
-rw------- vivien/vivien  1168 2021-12-30 10:43 python-magic-0.4.24/magic/loader.py
-rw------- vivien/vivien     0 2021-12-30 10:43 python-magic-0.4.24/magic/py.typed
```

As a result, they are not available for typechecking when using the package in another project.

To ship them, `*.pyi` files should be included as part of `package_data`: https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages.