### PR TITLE
added path for local homebrew installation

### DIFF
--- a/magic/loader.py
+++ b/magic/loader.py
@@ -14,6 +14,7 @@ def _lib_candidates():
       '/opt/local/lib',
       '/usr/local/lib',
       '/opt/homebrew/lib',
+      os.path.expanduser('~') + '/.brew/lib'
     ] + glob.glob('/usr/local/Cellar/libmagic/*/lib')
 
     for i in paths:


### PR DESCRIPTION
I wrote this little fix in order to access libmagic in mac even if it's installed with brew on user's home folder.