### PR TITLE
Add "magic-1.dll" to the list of DLL files to search for on Windows

### DIFF
--- a/magic/loader.py
+++ b/magic/loader.py
@@ -21,7 +21,7 @@ def _lib_candidates():
 
   elif sys.platform in ('win32', 'cygwin'):
 
-    prefixes = ['libmagic', 'magic1', 'cygmagic-1', 'libmagic-1', 'msys-magic-1']
+    prefixes = ['libmagic', 'magic1', 'magic-1', 'cygmagic-1', 'libmagic-1', 'msys-magic-1']
 
     for i in prefixes:
       # find_library searches in %PATH% but not the current directory,


### PR DESCRIPTION
This is the name of the DLL file generated when using vcpkg to build libmagic:
https://github.com/microsoft/vcpkg/tree/master/ports/libmagic