### PR TITLE
Add support for python-magic-bin DLL

### DIFF
--- a/magic/loader.py
+++ b/magic/loader.py
@@ -22,11 +22,13 @@ def _lib_candidates():
   elif sys.platform in ('win32', 'cygwin'):
 
     prefixes = ['libmagic', 'magic1', 'magic-1', 'cygmagic-1', 'libmagic-1', 'msys-magic-1']
-
+    
+    loader_path = os.path.dirname(__file__)
     for i in prefixes:
       # find_library searches in %PATH% but not the current directory,
       # so look for both
       yield './%s.dll' % (i,)
+      yield '%s/libmagic/%s.dll' % (loader_path, i,)
       yield find_library(i)
 
   elif sys.platform == 'linux':


### PR DESCRIPTION
This PR adds a workaround for the discovery of libmagic DLL provided by python-magic-bin in Windows.
In this way, the latest version of python-magic can be used in combination with python-magic-bin to work in Windows seamlessly for end users, as there is no dependency on outdated code from python-magic-bin.

Based on PR [#249](https://github.com/ahupp/python-magic/pull/249) by @av-gantimurov, created to allow fast merge
Related issue: [#248](https://github.com/ahupp/python-magic/issues/248#issuecomment-901053276)