### PR TITLE
chore(tests): add Python 3.10 and 3.11 in CI runs/tox/trove classifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10"
+  - "3.11"
 
 install:
   - pip install coverage coveralls codecov

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py38,
     py39,
     py310,
+    py311,
     mypy
 
 [testenv]


### PR DESCRIPTION
## Description

This PR adds Python 3.10 and 3.11 in CI runs/tox/trove classifier