### PR TITLE
Fix test suite with file 5.45

### DIFF
--- a/test/libmagic_test.py
+++ b/test/libmagic_test.py
@@ -15,7 +15,7 @@ class MagicTestCase(unittest.TestCase):
     filename = os.path.join(TESTDATA_DIR, 'test.pdf')
     expected_mime_type = 'application/pdf'
     expected_encoding = 'us-ascii'
-    expected_name = ('PDF document, version 1.2', 'PDF document, version 1.2, 2 pages')
+    expected_name = ('PDF document, version 1.2', 'PDF document, version 1.2, 2 pages', 'PDF document, version 1.2, 2 page(s)')
 
     def assert_result(self, result):
         self.assertEqual(result.mime_type, self.expected_mime_type)

--- a/test/python_magic_test.py
+++ b/test/python_magic_test.py
@@ -108,7 +108,8 @@ class MagicTest(unittest.TestCase):
             self.assert_values(m, {
                 'magic._pyc_': 'python 2.4 byte-compiled',
                 'test.pdf': ('PDF document, version 1.2',
-                             'PDF document, version 1.2, 2 pages'),
+                             'PDF document, version 1.2, 2 pages',
+                             'PDF document, version 1.2, 2 page(s)'),
                 'test.gz':
                     ('gzip compressed data, was "test", from Unix, last '
                      'modified: Sun Jun 29 01:32:52 2008',


### PR DESCRIPTION
[   12s] test/python_magic_test.py:53: in assert_values
[   12s]     self.assertIn(value, expected_value)
[   12s] E   AssertionError: 'PDF document, version 1.2, 2 page(s)' not found in ('PDF document, version 1.2', 'PDF document, version 1.2, 2 pages')
