### PR TITLE
fix: Don't raise FileNotFoundException on symlinks

### DIFF
--- a/magic/__init__.py
+++ b/magic/__init__.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 import sys
+import os
 import glob
 import ctypes
 import ctypes.util
@@ -24,9 +25,6 @@ import threading
 import logging
 
 from ctypes import c_char_p, c_int, c_size_t, c_void_p, byref, POINTER
-
-# avoid shadowing the real open with the version from compat.py
-_real_open = open
 
 
 class MagicException(Exception):
@@ -109,8 +107,7 @@ class Magic:
 
     def from_file(self, filename):
         # raise FileNotFoundException or IOError if the file does not exist
-        with _real_open(filename):
-            pass
+        os.stat(filename, follow_symlinks=self.flags & MAGIC_SYMLINK)
 
         with self.lock:
             try:


### PR DESCRIPTION
The builtin `open` will always follow symlinks.
Using `os.stat` is the easiest solution imo.
An alternative would be using `os.access` but that does not raise a FileNotFoundException so I chose `os.stat`.

As a sidenote I'd like to mention that setting `MAGIC_SYMLINK` is not possible, is it?