### PR TITLE
Travis CI: Test on Python 3.13 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "3.10"
   - "3.11"
   - "3.12"
+  - "3.13"
 
 install:
   - pip install coverage coveralls codecov


### PR DESCRIPTION
The Python 3.13 release notes mention `python-magic` as one of the alternatives for `imghdr` which was removed from the Standard Library so let's ensure that its tests pass on Python 3.13 beta.

https://www.python.org/downloads/release/python-3130b1/

May raise `ModuleNotFoundError: No module named 'imghdr'` because Python 3.13 removes it from the Standard Library.
* https://docs.python.org/3/library/imghdr.html

> imghdr: use the projects [filetype](https://pypi.org/project/filetype/), [puremagic](https://pypi.org/project/puremagic/), or [python-magic](https://pypi.org/project/python-magic/) instead. (Contributed by Victor Stinner in [gh-104773](https://github.com/python/cpython/issues/104773).)

https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-dead-batteries-and-other-module-removals