### PR TITLE
Re-enable two Linux tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: pip install --upgrade pip
       - run: pip install --upgrade pytest
       - run: pip install --editable .
+      - if: runner.os == 'Linux'
+        run: sudo apt-get install -y libmagic1
       - if: runner.os == 'macOS'
         run: brew install libmagic
       - if: runner.os == 'Windows'

--- a/test/python_magic_test.py
+++ b/test/python_magic_test.py
@@ -120,8 +120,6 @@ class MagicTest(unittest.TestCase):
         finally:
             os.unlink(dest)
 
-    # TODO: Fix this failing test on Ubuntu
-    @pytest.mark.skipif(sys.platform == "linux", reason="'JSON data' not found")
     def test_descriptions(self):
         m = magic.Magic()
         os.environ["TZ"] = "UTC"  # To get last modified date of test.gz in UTC
@@ -161,8 +159,6 @@ class MagicTest(unittest.TestCase):
         finally:
             del os.environ["TZ"]
 
-    # TODO: Fix this failing test on Ubuntu
-    @pytest.mark.skipif(sys.platform == "linux", reason="'JSON data' not found")
     def test_descriptions_no_soft(self):
         m = magic.Magic(check_soft=False)
         self.assert_values(


### PR DESCRIPTION
Fixes #321 
* #321
---
```yaml
      - if: runner.os == 'Linux'
        run: sudo apt-get install -y libmagic1
```
> sudo apt-get install -y libmagic1
Reading package lists...
Building dependency tree...
Reading state information...
libmagic1 is already the newest version (1:5.41-3ubuntu0.1).
libmagic1 set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.

@ddelange Your review, please.