### PR TITLE
Small Fix to ReadMe that makes pip install command easier to see/find

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ You can also combine the flag options:
 
 ## Installation
 
-The current stable version of python-magic is available on PyPI and
-can be installed by running `pip install python-magic`.
+The current stable version of Python-Magic is available on PyPI and
+can be installed by running:
+```
+pip install python-magic
+```
 
 Other sources:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can also combine the flag options:
 
 ## Installation
 
-The current stable version of Python-Magic is available on PyPI and
+The current stable version of python-magic is available on PyPI and
 can be installed by running:
 ```
 pip install python-magic


### PR DESCRIPTION
I wasn't able to really find the pip command quickly, so I thought this addition would help with readability and help people find the pip install command easier