### PR TITLE
Fix test for Apache Parquet files for file 5.47

### DIFF
--- a/test/python_magic_test.py
+++ b/test/python_magic_test.py
@@ -89,8 +89,8 @@ CASES = {
         (NO_SOFT, ["data"]),
     ],
     b"test.snappy.parquet": [
-        (COMMON_MIME, ["application/octet-stream"]),
-        (COMMON_PLAIN, ["Apache Parquet", "Par archive data"]),
+        (COMMON_MIME, ["application/octet-stream", "application/vnd.apache.parquet"]),
+        (COMMON_PLAIN, ["Apache Parquet", "Apache Parquet file", "Par archive data"]),
         (NO_SOFT, ["data"]),
     ],
     b"test.json": [


### PR DESCRIPTION
The output for Parquet files changed in 5.47. This PR edits the test to accept both the old and new output.

```sh
# Old
$ file example.parquet
example.parquet: Apache Parquet
$ file --mime example.parquet
example.parquet: application/octet-stream; charset=binary

# New
$ file example.parquet
example.parquet: Apache Parquet file
$ file --mime example.parquet
example.parquet: application/vnd.apache.parquet; charset=binary
```